### PR TITLE
fix(core): NamespaceFilesService inject include / exclude patterns don't mandate a leading '/' for patterns

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/NamespaceFilesService.java
+++ b/core/src/main/java/io/kestra/core/runners/NamespaceFilesService.java
@@ -97,7 +97,7 @@ public class NamespaceFilesService {
             .stream()
             .anyMatch(s -> FileSystems
                 .getDefault()
-                .getPathMatcher("glob:" + s)
+                .getPathMatcher("glob:" + (s.matches("\\w+[\\s\\S]*") ? "**/" + s : s))
                 .matches(Paths.get(file))
             );
     }


### PR DESCRIPTION
pr_rerun fix/optional-leading-slash-ns-files-include to develop